### PR TITLE
Fix attribute parameter

### DIFF
--- a/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
@@ -516,7 +516,7 @@ which require a preprocess.
   which I find a bit surprising but anyway I'll use the longr faster version.
 -->
 <xsl:variable name="context-xpath">
-  <xsl:if test="$attributes='true' and parent::node() ">@*|</xsl:if>
+  <xsl:if test="$attributes='true'">@*|</xsl:if>
   <xsl:choose>
     <xsl:when test="$only-child-elements='true'">*</xsl:when>
     <xsl:when test="$visit-text='true'">node()</xsl:when>


### PR DESCRIPTION
Currently the `attribute` XSLT parameter is ineffective because of the erroneous `parent::node()` check. Removing the needless check should resolve issue #29, and allow attributes as rule context again.