### PR TITLE
expand variables in `value` attributes too

### DIFF
--- a/trunk/schematron/code/iso_abstract_expand.xsl
+++ b/trunk/schematron/code/iso_abstract_expand.xsl
@@ -245,7 +245,7 @@ VERSION INFORMATION
 	<xslt:template mode="iae:do-pattern" match="*">
 		<xslt:param name="caller"/>
 		<xslt:copy>
-			<xslt:for-each select="@*[name()='test' or name()='context' or name()='select'   or name()='path'  ]">
+			<xslt:for-each select="@*[name()='test' or name()='context' or name()='select'   or name()='path' or name()='value']">
 				<xslt:attribute name="{name()}">
 				<xslt:call-template name="iae:macro-expand">
 						<xslt:with-param name="text"><xslt:value-of select="."/></xslt:with-param>
@@ -253,7 +253,7 @@ VERSION INFORMATION
 					</xslt:call-template>
 				</xslt:attribute>
 			</xslt:for-each>	
-			<xslt:copy-of select="@*[name()!='test'][name()!='context'][name()!='select'][name()!='path']" />
+			<xslt:copy-of select="@*[name()!='test'][name()!='context'][name()!='select'][name()!='path'][name()!='value']" />
 			<xsl:for-each select="node()">
 				<xsl:choose>
 				    <!-- Experiment: replace macros in text as well, to allow parameterized assertions


### PR DESCRIPTION
Hi!

I found an issue for expand abstract patterns.

I need to declare abstract pattern which uses external function inside (I use custom extensibility functions for .NET XslCompiledTransform) and I need to pass external parameter to this function. Then I need to assert function result multiple times.

Here is pseudocode:

```xml
<schema xmlns="http://purl.oclc.org/dsdl/schematron">
  <ns prefix="extension" uri="urn:extension" />

  <!-- declare abstract pattern -->
  <pattern abstract="true" id="abstract-pattern">
    <rule context="$context">
      <let name="someVariable" value="extension:function(@attribute, $externalParameter)" />
      <assert test="normalize-space($someVariable) = 'someValue1' ">
        error message
      </assert>
      <report test="normalize-space($someVariable) = 'someValue2' ">
        report message
      </report>
    </rule>
  </pattern>

  <!-- use abstract pattern -->
  <pattern is-a="abstract-pattern" id="concrete-pattern">
    <param name="$context" value="/*" />
    <param name="$externalParameter" value="999" />
  </pattern>
</schema>
```

The issue is that `iso_abstract_expand.xsl` does not substitute parameters for `value` attributes.

Please, consider this PR which fixes this behavior.
