### PR TITLE
Fixes to handling of attribute contexts

### DIFF
--- a/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
@@ -1561,6 +1561,9 @@ which require a preprocess.
 				 mode="M{ count(preceding-sibling::*) }">
 		    <axsl:apply-templates select="{$context-xpath}" mode="M{count(preceding-sibling::*)}"/>
 		  </axsl:template>
+		<axsl:template match="@*|comment()|text()|processing-instruction()"
+				priority="-2"
+				mode="M{ count(preceding-sibling::*) }"/>
 		</xsl:if>
       </xsl:if>
 	</xsl:template>

--- a/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
@@ -437,6 +437,7 @@ THE SOFTWARE.
     xmlns:exsl="http://exslt.org/common" 
     xmlns:xhtml="http://www.w3.org/1999/xhtml" 
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:oup="http://www.oup.com/schematron"
     extension-element-prefixes="exsl"
     version="2.0"
 	 >
@@ -516,7 +517,7 @@ which require a preprocess.
   which I find a bit surprising but anyway I'll use the longr faster version.
 -->
 <xsl:variable name="context-xpath">
-  <xsl:if test="$attributes='true'">@*|</xsl:if>
+	<xsl:if test="$attributes='true'">@*|</xsl:if>
   <xsl:choose>
     <xsl:when test="$only-child-elements='true'">*</xsl:when>
     <xsl:when test="$visit-text='true'">node()</xsl:when>

--- a/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
@@ -516,7 +516,7 @@ which require a preprocess.
   which I find a bit surprising but anyway I'll use the longr faster version.
 -->
 <xsl:variable name="context-xpath">
-  <xsl:if test="$attributes='true' and parent::node() ">@*|</xsl:if>
+  <xsl:if test="$attributes='true'">@*|</xsl:if>
   <xsl:choose>
     <xsl:when test="$only-child-elements='true'">*</xsl:when>
     <xsl:when test="$visit-text='true'">node()</xsl:when>
@@ -1556,7 +1556,7 @@ which require a preprocess.
 		  </axsl:template>
 		  
 		  <!-- DPC introduce context-xpath variable -->
-		  <axsl:template match="@*|node()"
+		  <axsl:template match="*"
 				 priority="-2"
 				 mode="M{ count(preceding-sibling::*) }">
 		    <axsl:apply-templates select="{$context-xpath}" mode="M{count(preceding-sibling::*)}"/>
@@ -1648,7 +1648,19 @@ which require a preprocess.
 				
 			<xsl:apply-templates/>
 			<!-- DPC introduce context-xpath and select-contexts variables -->
-			<xsl:if test="not($select-contexts)">
+			<xsl:variable name="isContextAnAttribute" as="xs:boolean">
+			  <xsl:variable name="contexts" select="tokenize(@context,'\|')"/>
+			<xsl:choose>
+					<xsl:when test="every $c in $contexts satisfies oup:isAttribute($c)">
+						<xsl:value-of select="true()"/>
+					</xsl:when>
+					<xsl:otherwise>
+						<xsl:value-of select="false()"/>
+					</xsl:otherwise>
+				</xsl:choose>
+			</xsl:variable>
+		<xsl:if test="not($select-contexts) 
+				and not($isContextAnAttribute)">
 			  <axsl:apply-templates select="{$context-xpath}" mode="M{count(../preceding-sibling::*)}"/>
 			</xsl:if>
 		</axsl:template>
@@ -1680,6 +1692,10 @@ which require a preprocess.
 		</xsl:call-template>
 	</xsl:template>
 
+	<!-- ISO TITLE -->
+	
+	<xsl:template match="oup:*" mode="#all"/>
+	
 	<!-- ISO TITLE -->
 	
 	<xsl:template match="iso:schema/iso:title"  priority="1">
@@ -2244,6 +2260,45 @@ which require a preprocess.
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>
+	
+<xsl:function name="oup:isAttribute" as="xs:boolean">
+		<xsl:param name="xpath-expression" as="xs:string"/>
+		<xsl:variable name="xpath-without-predicates" select="oup:stripPredicates($xpath-expression)" as="xs:string?"/>
+		<xsl:variable name="attributeName" as="xs:string?" select="substring-after($xpath-without-predicates,'@')"/>
+		
+		<xsl:choose>
+			<xsl:when test="$attributeName 
+				or matches($xpath-without-predicates, 'processing-instruction\(') 
+				or matches($xpath-without-predicates, 'text\(') 
+				or matches($xpath-without-predicates, 'comment\(')">
+				<xsl:value-of select="true()"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="false()"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:function>
+	
+	<xsl:function name="oup:stripPredicates" as="xs:string?">
+		<xsl:param name="xpath-expression" as="xs:string?"/>
+		<xsl:variable name="new-xpath-expression">
+			<xsl:analyze-string select="$xpath-expression" regex="\[[^\[\]]*\]">
+				<xsl:matching-substring/>
+				<xsl:non-matching-substring>
+					<xsl:value-of select="."/>
+				</xsl:non-matching-substring>
+			</xsl:analyze-string>	
+		</xsl:variable>
+		<xsl:choose>
+			<!-- handle nested predicates -->
+			<xsl:when test="matches($new-xpath-expression,'\[[^\[\]]*\]')">
+				<xsl:value-of select="oup:stripPredicates($new-xpath-expression)"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:value-of select="$new-xpath-expression"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:function>
 	
 <xhtml:div class="ErrorMessages">	
 	<!-- Where the error message contains dynamic information, the message has been split into an "a" and a "b" section.


### PR DESCRIPTION
Recognize when context is an attribute, comment, processing instruction, or text node.

So that compiled XSL does not contain xsl:apply-templates in match templates for attributes etc.

Also, allow rules with attribute contexts to work.