### PR TITLE
Add support for using variables in abstract patterns

### DIFF
--- a/trunk/schematron/code/iso_abstract_expand.xsl
+++ b/trunk/schematron/code/iso_abstract_expand.xsl
@@ -245,7 +245,7 @@ VERSION INFORMATION
 	<xslt:template mode="iae:do-pattern" match="*">
 		<xslt:param name="caller"/>
 		<xslt:copy>
-			<xslt:for-each select="@*[name()='test' or name()='context' or name()='select'   or name()='path'  ]">
+			<xslt:for-each select="@*[name()='test' or name()='context' or name()='select'   or name()='path' or name()='value']">
 				<xslt:attribute name="{name()}">
 				<xslt:call-template name="iae:macro-expand">
 						<xslt:with-param name="text"><xslt:value-of select="."/></xslt:with-param>
@@ -253,7 +253,7 @@ VERSION INFORMATION
 					</xslt:call-template>
 				</xslt:attribute>
 			</xslt:for-each>	
-			<xslt:copy-of select="@*[name()!='test'][name()!='context'][name()!='select'][name()!='path']" />
+		  <xslt:copy-of select="@*[name()!='test'][name()!='context'][name()!='select'][name()!='path'][name()!='value']" />
 			<xsl:for-each select="node()">
 				<xsl:choose>
 				    <!-- Experiment: replace macros in text as well, to allow parameterized assertions


### PR DESCRIPTION
Variable references in abstract patterns are replaced in value attribute as well in order to support let element. Original code wasn't replacing variable references in <sch:let/> elements.