### PR TITLE
Pass xsl:include in Schematron through to the compiled stylesheet

### DIFF
--- a/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
@@ -660,7 +660,7 @@ which require a preprocess.
     <xsl:text>&#10;&#10;</xsl:text><xsl:comment>XSD TYPES FOR XSLT2</xsl:comment><xsl:text>&#10;</xsl:text>
 	<xsl:apply-templates mode="do-types"   select="xsl:import-schema"/>
     <xsl:text>&#10;&#10;</xsl:text><xsl:comment>KEYS AND FUNCTIONS</xsl:comment><xsl:text>&#10;</xsl:text>
-	<xsl:apply-templates mode="do-keys"   select="xsl:key | xsl:function "/>
+	<xsl:apply-templates mode="do-keys"   select="xsl:key | xsl:function | xsl:include "/>
     <xsl:text>&#10;&#10;</xsl:text><xsl:comment>DEFAULT RULES</xsl:comment><xsl:text>&#10;</xsl:text>
     <xsl:call-template name="generate-default-rules" />
     <xsl:text>&#10;&#10;</xsl:text><xsl:comment>SCHEMA SETUP</xsl:comment><xsl:text>&#10;</xsl:text>
@@ -1199,6 +1199,10 @@ which require a preprocess.
 	<xsl:template match="iso:function "  >
 		<xsl:message><xsl:call-template name="outputLocalizedMessage" ><xsl:with-param name="number">17</xsl:with-param></xsl:call-template></xsl:message>
     </xsl:template>
+	
+	<xsl:template match="xsl:include" mode="do-keys">
+		<xsl:copy-of select="."/>
+	</xsl:template>
 
 
    <!-- ISO INCLUDE -->


### PR DESCRIPTION
This change allows using xsl:include in a Schematron to include an XSLT file. This currently works in oXygen 19.1 but does not work in the Schematron Skeleton XSLTs. A use case for this is to import an XSLT that contains a library of custom functions. It is currently possible to include xsl:function definitions in a Schematron though only in the main Schematron file, so this change allows for better organization and reusability. 

```xml
<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
    <sch:ns uri="function-library" prefix="lib"/>
    <xsl:include href="function-library.xsl"/>
    <sch:pattern>
        <sch:rule context="example">
            <sch:assert test="lib:check(.)">custom function check</sch:assert>
        </sch:rule>
    </sch:pattern>
</sch:schema>
```