### PR TITLE
Get the test submodule from an https: URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "trunk/schematron/test"]
 	path = trunk/schematron/test
-	url = git@github.com:Schematron/schematron-test.git
+	url = https://github.com/Schematron/schematron-test.git


### PR DESCRIPTION
Get the test submodule from https://github.com/Schematron/schematron-test.git .

This appears to resolve #65, see https://travis-ci.org/openaire/guidelines-cris-managers/builds/387507996 vs https://travis-ci.org/openaire/guidelines-cris-managers/builds/387354711 , the latter was failing with 

> fatal: Could not read from remote repository.