### PR TITLE
Reverse the logic of autodetecting `only-child-elements'

### DIFF
--- a/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_saxon.xsl
@@ -485,8 +485,8 @@ which require a preprocess.
 -->
 <xsl:param name="only-child-elements">
   <xsl:choose>
-    <xsl:when test="//iso:rule[contains(@context,'(')]">true</xsl:when>
-    <xsl:otherwise>false</xsl:otherwise>
+    <xsl:when test="//iso:rule[contains(@context,'(')]">false</xsl:when>
+    <xsl:otherwise>true</xsl:otherwise>
   </xsl:choose>
 </xsl:param>
 


### PR DESCRIPTION
Fix #71