### PR TITLE
Fix XSLT1 attribute paths

### DIFF
--- a/trunk/schematron/code/iso_schematron_skeleton_for_xslt1.xsl
+++ b/trunk/schematron/code/iso_schematron_skeleton_for_xslt1.xsl
@@ -692,6 +692,7 @@ THE SOFTWARE.
        	 	
        	 	
 		<axsl:template match="@*" mode="schematron-get-full-path">
+			<axsl:apply-templates select="parent::*" mode="schematron-get-full-path"/>
 		
 			<!-- XSLT1 syntax -->
 		<axsl:text>/</axsl:text>


### PR DESCRIPTION
Currently the path to an attribute context doesn't contain where it's located.

(Refs https://github.com/libero/jats-support/pull/1#discussion_r260236228)